### PR TITLE
Use Rails.root instead of deprecated RAILS_ROOT

### DIFF
--- a/lib/jelly/jelly_helper.rb
+++ b/lib/jelly/jelly_helper.rb
@@ -1,7 +1,7 @@
 module JellyHelper
   include Jelly::Common
 
-  def application_jelly_files(jelly_files_path_from_javascripts = '', rails_root = RAILS_ROOT)
+  def application_jelly_files(jelly_files_path_from_javascripts = '', rails_root = Rails.root)
     rails_root = File.expand_path(rails_root)
     (
       Dir[File.expand_path("#{rails_root}/public/javascripts/#{jelly_files_path_from_javascripts}/components/**/*.js")] +

--- a/spec/rails_root/config/boot.rb
+++ b/spec/rails_root/config/boot.rb
@@ -42,7 +42,7 @@ module Rails
 
   class VendorBoot < Boot
     def load_initializer
-      require "#{RAILS_ROOT}/vendor/rails/railties/lib/initializer"
+      require Rails.root.join("vendor/rails/railties/lib/initializer")
       Rails::Initializer.run(:install_gem_spec_stubs)
       Rails::GemDependency.add_frozen_gem_path
     end
@@ -100,7 +100,7 @@ module Rails
 
       private
         def read_environment_rb
-          File.read("#{RAILS_ROOT}/config/environment.rb")
+          File.read(Rails.root.join("/config/environment.rb"))
         end
     end
   end


### PR DESCRIPTION
We need this to make it work on rails > 3.1 apps.
